### PR TITLE
fix/이번달저축금액 계산 로직 수정, 기타 ui 수정

### DIFF
--- a/Smssme.xcodeproj/project.pbxproj
+++ b/Smssme.xcodeproj/project.pbxproj
@@ -99,13 +99,13 @@
 		9F2FA5852C868EB100A9731D /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2FA5842C868EB100A9731D /* DateManager.swift */; };
 		9F86E6CD2C92AB5F00619F7D /* AutomaticTransactionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F86E6CC2C92AB5F00619F7D /* AutomaticTransactionView.swift */; };
 		9F86E6CF2C92AB7100619F7D /* AutomaticTransactionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F86E6CE2C92AB7100619F7D /* AutomaticTransactionVC.swift */; };
-		9FDD4F6D2CA6F01200CC9247 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9FDD4F6B2CA6F01200CC9247 /* GoogleService-Info.plist */; };
-		9FDD4F6E2CA6F01200CC9247 /* SecretsConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9FDD4F6C2CA6F01200CC9247 /* SecretsConfig.xcconfig */; };
 		9FE549BF2C801E4D00E6075E /* FinancialPlanConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE549BE2C801E4D00E6075E /* FinancialPlanConfirmView.swift */; };
 		9FF702DB2C966B3F00890E77 /* RegexManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF702DA2C966B3F00890E77 /* RegexManager.swift */; };
 		E50498702CA5CB8D0014B8EF /* FinancialPlanCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E504986F2CA5CB8D0014B8EF /* FinancialPlanCompleteView.swift */; };
 		E517F2822C8782F200CB8680 /* FinancialPlanManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E517F2812C8782F200CB8680 /* FinancialPlanManager.swift */; };
 		E517F3402C89A41900CB8680 /* MoneyDiaryCreationVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E517F33F2C89A41900CB8680 /* MoneyDiaryCreationVC.swift */; };
+		E591BABB2CA816AE005E8E20 /* SecretsConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E591BAB92CA816AD005E8E20 /* SecretsConfig.xcconfig */; };
+		E591BABC2CA816AE005E8E20 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E591BABA2CA816AE005E8E20 /* GoogleService-Info.plist */; };
 		E5B9267D2CA2DF280027984E /* UILabelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B9267C2CA2DF280027984E /* UILabelFactory.swift */; };
 		E5B926832CA307E60027984E /* FinancialPlanCompleteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B926822CA307E60027984E /* FinancialPlanCompleteVC.swift */; };
 		E5B926872CA313FC0027984E /* UIButtonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B926862CA313FC0027984E /* UIButtonFactory.swift */; };
@@ -218,13 +218,13 @@
 		9F2FA5842C868EB100A9731D /* DateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateManager.swift; sourceTree = "<group>"; };
 		9F86E6CC2C92AB5F00619F7D /* AutomaticTransactionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticTransactionView.swift; sourceTree = "<group>"; };
 		9F86E6CE2C92AB7100619F7D /* AutomaticTransactionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticTransactionVC.swift; sourceTree = "<group>"; };
-		9FDD4F6B2CA6F01200CC9247 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		9FDD4F6C2CA6F01200CC9247 /* SecretsConfig.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = SecretsConfig.xcconfig; sourceTree = "<group>"; };
 		9FE549BE2C801E4D00E6075E /* FinancialPlanConfirmView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FinancialPlanConfirmView.swift; sourceTree = "<group>"; };
 		9FF702DA2C966B3F00890E77 /* RegexManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexManager.swift; sourceTree = "<group>"; };
 		E504986F2CA5CB8D0014B8EF /* FinancialPlanCompleteView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FinancialPlanCompleteView.swift; sourceTree = "<group>"; };
 		E517F2812C8782F200CB8680 /* FinancialPlanManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialPlanManager.swift; sourceTree = "<group>"; };
 		E517F33F2C89A41900CB8680 /* MoneyDiaryCreationVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyDiaryCreationVC.swift; sourceTree = "<group>"; };
+		E591BAB92CA816AD005E8E20 /* SecretsConfig.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = SecretsConfig.xcconfig; sourceTree = SOURCE_ROOT; };
+		E591BABA2CA816AE005E8E20 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		E5B9267C2CA2DF280027984E /* UILabelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabelFactory.swift; sourceTree = "<group>"; };
 		E5B926822CA307E60027984E /* FinancialPlanCompleteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FinancialPlanCompleteVC.swift; path = Smssme/Scenes/FinancialPlan/Controller/FinancialPlanCompleteVC.swift; sourceTree = SOURCE_ROOT; };
 		E5B926862CA313FC0027984E /* UIButtonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButtonFactory.swift; sourceTree = "<group>"; };
@@ -342,8 +342,8 @@
 			isa = PBXGroup;
 			children = (
 				74707FC12C85D78D00F7000C /* Smssme.entitlements */,
-				9FDD4F6B2CA6F01200CC9247 /* GoogleService-Info.plist */,
-				9FDD4F6C2CA6F01200CC9247 /* SecretsConfig.xcconfig */,
+				E591BABA2CA816AE005E8E20 /* GoogleService-Info.plist */,
+				E591BAB92CA816AD005E8E20 /* SecretsConfig.xcconfig */,
 				740350742C7740BE00122B2E /* Scenes */,
 				740350702C77408900122B2E /* Model */,
 				5FE400722C949DE9001D0FD1 /* Network */,
@@ -833,9 +833,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				740350632C773E9C00122B2E /* Assets.xcassets in Resources */,
-				9FDD4F6E2CA6F01200CC9247 /* SecretsConfig.xcconfig in Resources */,
-				9FDD4F6D2CA6F01200CC9247 /* GoogleService-Info.plist in Resources */,
+				E591BABC2CA816AE005E8E20 /* GoogleService-Info.plist in Resources */,
 				740350662C773E9C00122B2E /* Base in Resources */,
+				E591BABB2CA816AE005E8E20 /* SecretsConfig.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -975,7 +975,6 @@
 /* Begin XCBuildConfiguration section */
 		740350682C773E9C00122B2E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9FDD4F6C2CA6F01200CC9247 /* SecretsConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -1039,7 +1038,6 @@
 		};
 		740350692C773E9C00122B2E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9FDD4F6C2CA6F01200CC9247 /* SecretsConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/Smssme/Scenes/Authentication/Login/View/LoginView.swift
+++ b/Smssme/Scenes/Authentication/Login/View/LoginView.swift
@@ -103,9 +103,9 @@ final class LoginView: UIView {
     
     private func setupLayout() {
         logoImageView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(16)
-            $0.leading.equalToSuperview().offset(40)
-            $0.trailing.equalToSuperview().offset(-40)
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(24)
+            $0.leading.equalToSuperview().offset(60)
+            $0.trailing.equalToSuperview().offset(-60)
             $0.height.equalTo(logoImageView.snp.width)
         }
         

--- a/Smssme/Scenes/FinancialPlan/View/FinancialPlanConfirmView.swift
+++ b/Smssme/Scenes/FinancialPlan/View/FinancialPlanConfirmView.swift
@@ -247,7 +247,7 @@ class ButtonIncomplete: UIView {
             $0.bottom.equalToSuperview()
             $0.width.equalTo(80)
             $0.height.equalTo(40)
-            $0.leading.equalToSuperview().offset(40)
+            $0.leading.equalToSuperview().offset(80)
             $0.centerY.equalToSuperview()
         }
         
@@ -255,7 +255,7 @@ class ButtonIncomplete: UIView {
             $0.bottom.equalToSuperview()
             $0.width.equalTo(80)
             $0.height.equalTo(40)
-            $0.trailing.equalToSuperview().offset(-40)
+            $0.trailing.equalToSuperview().offset(-80)
             $0.centerY.equalToSuperview()
         }
     }


### PR DESCRIPTION
## 구현사항
이번달 저축금액 로직 수정,
로고 크기 살짝 작게, 버튼 위치수정

## 특이사항
이번달 저축금액
= 총 기간이 29일 이어도 일수가 중간에 걸치면 3달일 수 있음.  364일이어도 13개월일 수 있음

## 스크린샷(선택)
|로고크기줄임|저축금액수정|
|:---:|:---:|
|<img src="https://github.com/user-attachments/assets/a7a42050-bb73-422c-bff1-1e6cb37a4476" width="400">|<img src="https://github.com/user-attachments/assets/e8b71606-dc35-4886-a66f-6c2cffc3e5d3" width="400">
